### PR TITLE
Symfony2 profiler breaking when requests index is not set.

### DIFF
--- a/DataCollector/BitlyDataCollector.php
+++ b/DataCollector/BitlyDataCollector.php
@@ -41,7 +41,11 @@ class BitlyDataCollector extends DataCollector
 
     public function getRequests()
     {
-        return $this->data['requests'];
+        if(isset($this->data['requests'])) {
+            return $this->data['requests'];
+        } else {
+            return null;
+        }
     }
 
     public function getName()


### PR DESCRIPTION
Adding conditional logic around getRequests() to fix issue with Symfony2 profiler breaking when requests index is not set