### PR TITLE
Fix monolog_service.yml

### DIFF
--- a/Resources/config/monolog_service.yml
+++ b/Resources/config/monolog_service.yml
@@ -1,7 +1,7 @@
 services:
     hpatoio_bitly.log.monolog:
         class: "Guzzle\\Plugin\\Log\\LogPlugin"
-        arguments: [@hpatoio_bitly.log.monolog.adapter, %hpatoio_bitly.log.format%]
+        arguments: ["@hpatoio_bitly.log.monolog.adapter", %hpatoio_bitly.log.format%]
     hpatoio_bitly.log.monolog.adapter:
         class: "Guzzle\\Log\\MonologLogAdapter"
         arguments: ["@logger"]


### PR DESCRIPTION
The "@" can't start a plain text scalar, so you'll have to use quotes to surround it.