### PR TITLE
Fix yaml format

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,4 +1,4 @@
 services:
     hpatoio_bitly.client:
         class: "Hpatoio\\Bitly\\Client"
-        arguments: [%hpatoio_bitly.access_token%]
+        arguments: [ "%hpatoio_bitly.access_token%" ]


### PR DESCRIPTION
Fixes "User Deprecated: Not quoting the scalar "%hpatoio_bitly.access_token%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0. " deprecation warnings